### PR TITLE
Remove tototoshi-csv and better-files dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,7 @@ bucketSuffix  := "era7.com"
 
 libraryDependencies ++= Seq(
   "ohnosequences"         %% "cosas"        % "0.8.0",
-  "com.github.pathikrit"  %% "better-files" % "2.13.0",
-  "com.github.tototoshi"  %% "scala-csv"    % "1.2.2"
+  "com.github.pathikrit"  %% "better-files" % "2.13.0"
 )
 
 // NOTE should be reestablished

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,7 @@ description   := "A typesafe Scala API for FLASh"
 bucketSuffix  := "era7.com"
 
 libraryDependencies ++= Seq(
-  "ohnosequences"         %% "cosas"        % "0.8.0",
-  "com.github.pathikrit"  %% "better-files" % "2.13.0"
+  "ohnosequences" %% "cosas" % "0.8.0"
 )
 
 // NOTE should be reestablished

--- a/src/main/scala/api.scala
+++ b/src/main/scala/api.scala
@@ -1,7 +1,9 @@
 package ohnosequences.flash
 
 import ohnosequences.cosas._, types._, records._, fns._, klists._
-import better.files._
+import scala.collection.JavaConversions._
+import java.nio.file.Files
+import java.io._
 
 case object api {
 
@@ -170,7 +172,7 @@ case object api {
   // this does not correspond directly to a FLASh option, but to a set of them
   case object output extends FlashOption[FlashOutput]( fout =>
     Seq("--output-prefix", fout.prefix) ++
-    Seq("--output-directory", fout.outputPath.path.toString)
+    Seq("--output-directory", fout.outputPath.getCanonicalPath)
   )
   sealed trait FlashOutput {
 
@@ -185,11 +187,11 @@ case object api {
   }
   case class FlashOutputAt(val outputPath: File, val prefix: String) extends FlashOutput {
 
-    lazy val mergedReads: File            = outputPath / s"${prefix}.extendedFrags.fastq"
-    lazy val pair1NotMerged: File         = outputPath / s"${prefix}.notCombined_1.fastq"
-    lazy val pair2NotMerged: File         = outputPath / s"${prefix}.notCombined_2.fastq"
-    lazy val lengthNumericHistogram: File = outputPath / s"${prefix}.hist"
-    lazy val lengthVisualHistogram: File  = outputPath / s"${prefix}.histogram"
+    lazy val mergedReads: File            = new File(s"outputPath/${prefix}.extendedFrags.fastq")
+    lazy val pair1NotMerged: File         = new File(s"outputPath/${prefix}.notCombined_1.fastq")
+    lazy val pair2NotMerged: File         = new File(s"outputPath/${prefix}.notCombined_2.fastq")
+    lazy val lengthNumericHistogram: File = new File(s"outputPath/${prefix}.hist")
+    lazy val lengthVisualHistogram: File  = new File(s"outputPath/${prefix}.histogram")
   }
 
   // TODO add naive parsers and serializers
@@ -218,19 +220,22 @@ case object api {
   case class FlashOutputOps[FO <: FlashOutput](output: FO) extends AnyVal {
 
     // TODO better type (File errors etc)
-    final def stats: Seq[
+    final def stats: Iterator[
       Either[
         ParseDenotationsError,
         mergedStats.type := ( (mergedReadLength.type := Int) :: (readNumber := Int) :: *[AnyDenotation] )
       ]
     ] = {
 
-      def rows(lines: Iterator[Seq[String]])(headers: Seq[String]): Iterator[Map[String,String]] =
-        lines map { line => (headers zip line) toMap }
+      val header: Seq[String] = mergedStats.keys.types map typeLabel toList
 
-      rows(output.lengthNumericHistogram.lines.map(_.split('\t')))(
-        mergedStats.keys.types map typeLabel toList
-      ) map { mergedStats parse _ } toList
+      Files
+        .lines(output.lengthNumericHistogram.toPath).iterator
+        .map { str: String =>
+
+          val row: Seq[String] = str.split('\t')
+          mergedStats parse (header zip row).toMap
+        }
     }
   }
 
@@ -238,7 +243,7 @@ case object api {
     We are restricting Flash input to be provided as a pair of `fastq` files, specified through a value of type `FlashInput`
   */
   case object input extends FlashOption[FlashInput]( fin =>
-    Seq(fin.pair1.path.toString, fin.pair2.path.toString)
+    Seq(fin.pair1.getCanonicalPath, fin.pair2.getCanonicalPath)
   )
   sealed trait FlashInput {
 

--- a/src/main/scala/api.scala
+++ b/src/main/scala/api.scala
@@ -225,13 +225,10 @@ case object api {
       ]
     ] = {
 
-      import com.github.tototoshi.csv._
-      val csvReader = CSVReader.open(output.lengthNumericHistogram.toJava)(new TSVFormat {})
-
       def rows(lines: Iterator[Seq[String]])(headers: Seq[String]): Iterator[Map[String,String]] =
         lines map { line => (headers zip line) toMap }
 
-      rows(csvReader iterator)(
+      rows(output.lengthNumericHistogram.lines.map(_.split('\t')))(
         mergedStats.keys.types map typeLabel toList
       ) map { mergedStats parse _ } toList
     }

--- a/src/test/scala/CommandGeneration.scala
+++ b/src/test/scala/CommandGeneration.scala
@@ -1,11 +1,9 @@
 package ohnosequences.flash.test
 
 import org.scalatest.FunSuite
-
 import ohnosequences.flash._, api._
-
-import better.files._
 import ohnosequences.cosas._, types._, klists._
+import java.io._
 
 class CommandGeneration extends FunSuite {
 
@@ -13,8 +11,8 @@ class CommandGeneration extends FunSuite {
 
     val flashExpr = FlashExpression(
       flash.arguments(
-        (input   := FlashInputAt(File("reads1.fastq"), File("reads2.fastq")) ) ::
-        (output  := FlashOutputAt(File("/tmp/out"), "sample1")               ) :: *[AnyDenotation]
+        (input   := FlashInputAt(new File("reads1.fastq"), new File("reads2.fastq")) ) ::
+        (output  := FlashOutputAt(new File("/tmp/out"), "sample1")               ) :: *[AnyDenotation]
       ),
       flash.defaults update (allow_outies(true) :: *[AnyDenotation])
     )
@@ -22,10 +20,10 @@ class CommandGeneration extends FunSuite {
     assert {
       flashExpr.cmd === Seq(
         "flash",
-        File("reads1.fastq").path.toString,
-        File("reads2.fastq").path.toString,
+        new File("reads1.fastq").getCanonicalPath,
+        new File("reads2.fastq").getCanonicalPath,
         "--output-prefix", "sample1",
-        "--output-directory", File("/tmp/out").path.toString,
+        "--output-directory", new File("/tmp/out").getCanonicalPath,
         "--min-overlap", "10",
         "--max-overlap", "65",
         "--read-len", "100",

--- a/src/test/scala/ParseMergeStats.scala
+++ b/src/test/scala/ParseMergeStats.scala
@@ -1,18 +1,16 @@
 package ohnosequences.flash.test
 
 import org.scalatest.FunSuite
-
 import ohnosequences.flash._, api._
-
-import better.files._
 import ohnosequences.cosas._, types._, records._
+import java.io._
 
 class ParseMergeStats extends FunSuite {
 
   test("can get mergeStats record values from output file") {
 
     val output = FlashOutputAt(
-      outputPath = File("."),
+      outputPath = new File("."),
       prefix = "out"
     )
 


### PR DESCRIPTION
I don't think that this dependency is needed for using just an iterator over a csv file in **one** place in this lib.
